### PR TITLE
Second-edition styles

### DIFF
--- a/excerpts/0x00-Header.html
+++ b/excerpts/0x00-Header.html
@@ -128,14 +128,42 @@
     text-align: left;
   }
 
-  ol {
+  p:has(+ ol) {
     break-before: avoid;
+  }
+
+  #sec-- ol li:first-child {
+    break-after: avoid;
+  }
+
+  #sec-- ol li:last-child {
+    break-before: avoid;
+  }
+
+  emu-example:only-of-type {
+    break-before: avoid;
+  }
+
+  /* This style is here to handle when elements are generated between emu-clauses in Ecmarkup.js. Safe to delete once
+   that bug is remedied */
+  emu-clause + p:has(+ ol) {
+    break-before: auto;
+    break-after: avoid;
+  }
+
+  /* These styles are specifically for the print version of the second edition, probably best to delete and start over
+   with clause-specific styles in future editions  */
+  #sec--metadata-lifecycles- > p:has(+ ol),
+  #sec--components-cryptoproperties-certificateproperties-certificateextensions- > p:has(+ ol),
+  #sec--formulation-workflows-tasks-trigger-inputs-source-ref { /* This is not a typo or missing a p */
+    break-before: page;
   }
 </style>
 <pre class="metadata">
   title: CycloneDX Bill of materials specification
   shortname: ECMA-424
   status: standard
+  committee: 54
   location: https://tc54.org/ecma424/
   markEffects: true
   version: 2<sup>nd</sup> Edition

--- a/excerpts/0x10-Introduction.html
+++ b/excerpts/0x10-Introduction.html
@@ -21,5 +21,4 @@
     components, CycloneDX enables organizations to achieve greater security and reliability in their supply chains,
     supporting a wide range of use cases from product security to vendor risk management.
   </p>
-  <p class="adoption-info">This Ecma Standard was developed by Technical Committee 54 and was adopted by the General Assembly of December 2025.</p>
 </emu-intro>

--- a/excerpts/0x30-Overview.html
+++ b/excerpts/0x30-Overview.html
@@ -175,7 +175,7 @@
       VDRs communicate known and unknown vulnerabilities affecting components and services. Known vulnerabilities
       inherited from the use of third-party and open-source software can be communicated with CycloneDX. Previously
       unknown vulnerabilities affecting both components and services may also be disclosed using CycloneDX, making
-      it ideal for Vulnerability Disclosure \Report (VDR) use cases. CycloneDX exceeds the data field requirements
+      it ideal for Vulnerability Disclosure Report (VDR) use cases. CycloneDX exceeds the data field requirements
       defined in <a href="https://www.iso.org/standard/72311.html">ISO/IEC 29147:2018</a> for vulnerability
       disclosure information.
     </p>


### PR DESCRIPTION
Leaving a nice little note for future secretary. Additionally, committee is now a required metadata field in ecmarkup. If status is set to "standard", date and committee are required. ecmarkup will insert the adoption info note automatically.