### PR TITLE
Reword definitions to align with Ecma house style

### DIFF
--- a/excerpts/0x20-Scope-Conformance-References.html
+++ b/excerpts/0x20-Scope-Conformance-References.html
@@ -72,72 +72,93 @@
 <emu-clause id="sec-terms-and-definitions">
   <h1>Terms and definitions</h1>
   <p>For the purposes of this document, the following terms and definitions apply. Terms explicitly defined in this Standard are not to be presumed to refer implicitly to similar terms defined elsewhere.</p>
+
   <emu-clause id="sec-terms-and-definitions-attestation">
     <h1>attestation</h1>
-    <p>A formal declaration that something is true or accurate, often backed by documentation or verification from an authoritative source. It serves as a confirmation or proof of a fact, condition, or compliance with specific standards or requirements.</p>
+    <p>formal declaration that something is true or accurate</p>
+    <emu-note>
+      <p>
+        Attestations are often backed by documentation or verification from an authoritative source. An attestation serves as a confirmation or proof of a fact, condition, or compliance with specific standards or requirements.
+      </p>
+    </emu-note>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-author">
     <h1>author</h1>
-    <p>A person who creates written works, such as software or data.</p>
+    <p>person who creates written works, such as software or data</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-component-function">
     <h1>component function</h1>
-    <p>The purpose for which a software component exists. Examples of component functions include parsers, database persistence, and authentication providers.</p>
+    <p>purpose for which a software component exists</p>
+    <emu-note>
+      <p>Examples of component functions include parsers, database persistence, and authentication providers.</p>
+    </emu-note>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-component-type">
     <h1>component type</h1>
-    <p>The general classification of a software components architecture. Examples of component types include libraries, frameworks, applications, containers, and operating systems.</p>
+    <p>general classification of a software components architecture</p>
+    <emu-note>
+      <p>Examples of component types include libraries, frameworks, applications, containers, and operating systems.</p>
+    </emu-note>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-manufacturer">
     <h1>manufacturer</h1>
-    <p>An entity that develops and produces products such as virtual or physical goods.</p>
+    <p>entity that develops and produces products such as virtual or physical goods</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-direct-dependency">
     <h1>direct dependency</h1>
-    <p>A component that is referenced by a main (metadata) component itself.</p>
+    <p>component that is referenced by a main (metadata) component itself</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-purl">
     <h1>Package-URL (PURL)</h1>
-    <p>An ecosystem-agnostic specification which standardizes the syntax and location information of software components.</p>
+    <p>ecosystem-agnostic specification which standardizes the syntax and location information of software components</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-pedigree">
     <h1>pedigree</h1>
-    <p>Data which describes the lineage and/or process for which software has been created or altered.</p>
+    <p>data which describes the lineage and/or process for which software has been created or altered</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-procurement">
     <h1>procurement</h1>
-    <p>The process of agreeing to terms and acquiring physical or virtual goods or services.</p>
+    <p>process of agreeing to terms and acquiring physical or virtual goods or services</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-provenance">
     <h1>provenance</h1>
-    <p>The chain of custody and origin of a software component. Provenance incorporates the point of origin through distribution as well as derivatives in the case of software that has been modified.</p>
+    <p>chain of custody and origin of a software component</p>
+    <emu-note>
+      <p>Provenance incorporates the point of origin through distribution as well as derivatives in the case of software that has been modified.</p>
+    </emu-note>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-provider">
     <h1>provider</h1>
-    <p>An entity that offers services, infrastructure, or platforms. These services can include computing resources, storage, software applications, and networking capabilities.</p>
+    <p>entity that offers services, infrastructure, or platforms</p>
+    <emu-note>
+      <p>These services can include computing resources, storage, software applications, and networking capabilities.</p>
+    </emu-note>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-publisher">
     <h1>publisher</h1>
-    <p>An entity that produces and distributes content, such as software, to the public.</p>
+    <p>entity that produces and distributes content, such as software, to the public</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-swid">
     <h1>Software identification (SWID)</h1>
-    <p>An ISO standard that formalizes XML records that uniquely identify software products, versions, and installations to support asset management, security, and compliance.</p>
+    <p>ISO standard that formalizes XML records that uniquely identify software products, versions, and installations to support asset management, security, and compliance</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-spdx">
     <h1>Software Package Data Exchange (SPDX)</h1>
-    <p>A Linux Foundation project which produces a standardized list of open source licences and defines an expression language for those licences.</p>
+    <p>Linux Foundation project which produces a standardized list of open source licences and defines an expression language for those licences</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-supplier">
     <h1>supplier</h1>
-    <p>An entity that provides products or services to another entity, typically within a supply chain.</p>
+    <p>entity that provides products or services to another entity, typically within a supply chain</p>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-third-party-component">
     <h1>third-party component</h1>
-    <p>Any software component not directly created including open source, "source available", and commercial or proprietary software.</p>
+    <p>software component not directly created</p>
+    <emu-note>
+      <p>Third-party components may include open source, "source available", and commercial or proprietary software.</p>
+    </emu-note>
   </emu-clause>
   <emu-clause id="sec-terms-and-definitions-transitive-dependency">
     <h1>transitive dependency</h1>
-    <p>A software component that is indirectly used by another component by means of being a dependency of a dependency.</p>
+    <p>software component that is indirectly used by another component by means of being a dependency of a dependency</p>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
From ISO-IEC Directive part 2 9th edition as referenced from Ecma TOOLS-011:

> The definition shall be written in such a form that it can replace the term in its context. It shall not start with an article (“the”, “a”) nor end with a full stop.